### PR TITLE
Add basic NestJS + React chat

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-react"]
+}

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "chat-client",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "socket.io-client": "^4.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^9.0.0",
+    "webpack": "^5.0.0",
+    "webpack-cli": "^5.0.0",
+    "webpack-dev-server": "^4.0.0"
+  }
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Chat App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="bundle.js"></script>
+  </body>
+</html>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import Chat from './Chat';
+
+export default function App() {
+  return (
+    <div>
+      <h1>Chat</h1>
+      <Chat />
+    </div>
+  );
+}

--- a/client/src/Chat.js
+++ b/client/src/Chat.js
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import io from 'socket.io-client';
+
+const socket = io('http://localhost:3001');
+
+export default function Chat() {
+  const [messages, setMessages] = useState([]);
+  const [text, setText] = useState('');
+  const [user, setUser] = useState('');
+
+  useEffect(() => {
+    socket.emit('findAll');
+    socket.on('message', msg => setMessages(prev => [...prev, msg]));
+    socket.on('allMessages', msgs => setMessages(msgs));
+    return () => {
+      socket.off('message');
+      socket.off('allMessages');
+    };
+  }, []);
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    socket.emit('message', { user, text });
+    setText('');
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit}>
+        <input value={user} onChange={e => setUser(e.target.value)} placeholder="User" />
+        <input value={text} onChange={e => setText(e.target.value)} placeholder="Message" />
+        <button type="submit">Send</button>
+      </form>
+      <ul>
+        {messages.map(msg => (
+          <li key={msg._id}>{msg.user}: {msg.text}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,0 +1,30 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'public'),
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react']
+          }
+        }
+      }
+    ]
+  },
+  devServer: {
+    static: path.join(__dirname, 'public'),
+    port: 3000
+  },
+  resolve: {
+    extensions: ['.js', '.jsx']
+  }
+};

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "chat-server",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "nest start"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/platform-socket.io": "^10.0.0",
+    "@nestjs/websockets": "^10.0.0",
+    "mongoose": "^7.0.0",
+    "@nestjs/mongoose": "^10.0.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { MessagesModule } from './messages/messages.module';
+
+@Module({
+  imports: [
+    MongooseModule.forRoot('mongodb://localhost/chat'),
+    MessagesModule,
+  ],
+})
+export class AppModule {}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3001);
+  console.log('Server listening on port 3001');
+}
+bootstrap();

--- a/server/src/messages/message.schema.ts
+++ b/server/src/messages/message.schema.ts
@@ -1,0 +1,13 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Message extends Document {
+  @Prop()
+  user: string;
+
+  @Prop()
+  text: string;
+}
+
+export const MessageSchema = SchemaFactory.createForClass(Message);

--- a/server/src/messages/messages.gateway.ts
+++ b/server/src/messages/messages.gateway.ts
@@ -1,0 +1,23 @@
+import { WebSocketGateway, WebSocketServer, SubscribeMessage, MessageBody } from '@nestjs/websockets';
+import { Server } from 'socket.io';
+import { MessagesService } from './messages.service';
+
+@WebSocketGateway()
+export class MessagesGateway {
+  @WebSocketServer()
+  server: Server;
+
+  constructor(private messagesService: MessagesService) {}
+
+  @SubscribeMessage('message')
+  async handleMessage(@MessageBody() data: { user: string; text: string }) {
+    const message = await this.messagesService.create(data.user, data.text);
+    this.server.emit('message', message);
+  }
+
+  @SubscribeMessage('findAll')
+  async handleFindAll() {
+    const messages = await this.messagesService.findAll();
+    this.server.emit('allMessages', messages);
+  }
+}

--- a/server/src/messages/messages.module.ts
+++ b/server/src/messages/messages.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { MessagesGateway } from './messages.gateway';
+import { MessagesService } from './messages.service';
+import { Message, MessageSchema } from './message.schema';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: Message.name, schema: MessageSchema }])],
+  providers: [MessagesGateway, MessagesService],
+})
+export class MessagesModule {}

--- a/server/src/messages/messages.service.ts
+++ b/server/src/messages/messages.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Message } from './message.schema';
+
+@Injectable()
+export class MessagesService {
+  constructor(@InjectModel(Message.name) private messageModel: Model<Message>) {}
+
+  async create(user: string, text: string) {
+    const created = new this.messageModel({ user, text });
+    return created.save();
+  }
+
+  async findAll() {
+    return this.messageModel.find().exec();
+  }
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- initialize server with NestJS websocket gateway and MongoDB
- add React client that connects with socket.io
- add webpack/Babel setup for React app

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685105704778833089648554a806ffa1